### PR TITLE
feat: Typography로 폰트 컨트롤

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,6 +3,18 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;500;700&family=Roboto:wght@300;500;700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      as="style"
+      crossorigin
+      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.8/dist/web/static/pretendard.css"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>킹모장</title>
   </head>

--- a/web/src/components/Header/Header.css.ts
+++ b/web/src/components/Header/Header.css.ts
@@ -1,6 +1,12 @@
 import { style } from "@vanilla-extract/css";
 
+import { Typography } from "../../styles/typography";
+
 export const HeaderStyle = style({
+  ...Typography({
+    font: "Pretendard",
+    weight: "400",
+  }),
   position: "relative",
   display: "flex",
   alignItems: "center",

--- a/web/src/styles/global.css.ts
+++ b/web/src/styles/global.css.ts
@@ -3,6 +3,7 @@ import { globalStyle } from "@vanilla-extract/css";
 globalStyle("html, body", {
   margin: 0,
   padding: 0,
+  fontFamily: "Noto Sans, Roboto, Pretendard",
 });
 
 globalStyle("body", {
@@ -21,8 +22,6 @@ globalStyle(
     border: "0",
     fontSize: "100%",
     verticalAlign: "baseline",
-    fontFamily:
-      '-apple-system, BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji"',
   },
 );
 

--- a/web/src/styles/typography.ts
+++ b/web/src/styles/typography.ts
@@ -1,0 +1,15 @@
+type SizeProps = "12" | "14" | "16" | "18" | "24" | "26" | "28" | "32" | "34";
+type WeightProps = "400" | "500" | "700";
+type FontProps = "Noto Sans" | "Roboto" | "Pretendard";
+
+type TypographyProps = {
+  size?: SizeProps;
+  weight?: WeightProps;
+  font?: FontProps;
+};
+
+export const Typography = ({ font, size, weight }: TypographyProps) => ({
+  fontSize: `${size}px` || "1rem",
+  fontWeight: `${weight}` || "400",
+  fontFamily: `${font}` || "Noto Sans",
+});


### PR DESCRIPTION
<img width="756" alt="스크린샷 2023-08-18 오후 2 12 15" src="https://github.com/canyonfrs/kingmojang/assets/49175629/50d0972d-e9a4-49e3-8def-aae0822ad7a1">

일단 이렇게 만들었고, 아래처럼 쓸 수 있게 했음. 

<img width="301" alt="스크린샷 2023-08-18 오후 2 12 29" src="https://github.com/canyonfrs/kingmojang/assets/49175629/a5ad6d23-4656-4928-81cd-645141972ff8">
